### PR TITLE
Add basic scanning, payment and automatic reset

### DIFF
--- a/CaisseAutomatique/Model/Automates/Automate.cs
+++ b/CaisseAutomatique/Model/Automates/Automate.cs
@@ -1,4 +1,5 @@
 using System;
+using CaisseAutomatique.Model;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -12,13 +13,17 @@ namespace CaisseAutomatique.Model.Automates
         private Etat etatCourant;
         public Etat EtatCourant { get => etatCourant; private set => etatCourant = value; }
 
+        private Caisse caisse;
+        public Caisse Caisse => caisse;
+
         /// <summary>
         /// Message actuel de la caisse (donné par l'état courant)
         /// </summary>
         public string Message => this.etatCourant.Message;
 
-        public Automate()
+        public Automate(Caisse caisse)
         {
+            this.caisse = caisse;
             this.etatCourant = new Etats.EtatAttenteClient(this);
         }
 

--- a/CaisseAutomatique/Model/Automates/Etats/EtatAttenteArticle.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatAttenteArticle.cs
@@ -1,0 +1,31 @@
+using CaisseAutomatique.Model.Automates;
+
+namespace CaisseAutomatique.Model.Automates.Etats
+{
+    /// <summary>
+    /// Etat après le premier scan, en attente des scans suivants ou du paiement
+    /// </summary>
+    public class EtatAttenteArticle : Etat
+    {
+        public EtatAttenteArticle(Automate automate) : base(automate)
+        {
+        }
+
+        public override void Action(Evenement evt)
+        {
+            // aucune action spécifique
+        }
+
+        public override Etat Transition(Evenement evt)
+        {
+            return evt switch
+            {
+                Evenement.SCAN => new EtatAttenteArticle(this.automate),
+                Evenement.PAYE => new EtatFin(this.automate),
+                _ => this
+            };
+        }
+
+        public override string Message => "Scannez le produit suivant !";
+    }
+}

--- a/CaisseAutomatique/Model/Automates/Etats/EtatAttenteClient.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatAttenteClient.cs
@@ -16,8 +16,11 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override Etat Transition(Evenement evt)
         {
-            // Pour l'instant, la transition revient sur le même état
-            return new EtatAttenteClient(this.automate);
+            if (evt == Evenement.SCAN)
+            {
+                return new EtatAttenteArticle(this.automate);
+            }
+            return this;
         }
 
         public override string Message => "Bonjour, scannez votre premier article !";

--- a/CaisseAutomatique/Model/Automates/Etats/EtatFin.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatFin.cs
@@ -1,0 +1,50 @@
+using System.Timers;
+using System.Windows;
+
+namespace CaisseAutomatique.Model.Automates.Etats
+{
+    /// <summary>
+    /// Etat final affichant au revoir puis déclenchant un reset automatique
+    /// </summary>
+    public class EtatFin : Etat
+    {
+        private static Timer? timer = null;
+
+        public EtatFin(Automate automate) : base(automate)
+        {
+            if (timer == null)
+            {
+                timer = new Timer(2000);
+                timer.Elapsed += Timer_Elapsed;
+                timer.AutoReset = false;
+                timer.Start();
+            }
+        }
+
+        private void Timer_Elapsed(object? sender, ElapsedEventArgs e)
+        {
+            timer?.Stop();
+            timer = null;
+            Application.Current.Dispatcher.Invoke(() => this.automate.Activer(Evenement.RESET));
+        }
+
+        public override void Action(Evenement evt)
+        {
+            if (evt == Evenement.RESET)
+            {
+                this.automate.Caisse.Reset();
+            }
+        }
+
+        public override Etat Transition(Evenement evt)
+        {
+            if (evt == Evenement.RESET)
+            {
+                return new EtatAttenteClient(this.automate);
+            }
+            return this;
+        }
+
+        public override string Message => "Au revoir";
+    }
+}

--- a/CaisseAutomatique/Model/Automates/Evenement.cs
+++ b/CaisseAutomatique/Model/Automates/Evenement.cs
@@ -6,5 +6,8 @@ namespace CaisseAutomatique.Model.Automates
     /// </summary>
     public enum Evenement
     {
+        SCAN,
+        PAYE,
+        RESET
     }
 }

--- a/CaisseAutomatique/Model/Caisse.cs
+++ b/CaisseAutomatique/Model/Caisse.cs
@@ -93,6 +93,41 @@ namespace CaisseAutomatique.Model
         }
 
         /// <summary>
+        /// Enregistre un article scanné par le client
+        /// </summary>
+        /// <param name="article">Article scanné</param>
+        public void EnregistrerArticle(Article article)
+        {
+            this.articles.Add(article);
+            this.dernierArticleScanne = article;
+            this.NotifyPropertyChanged(nameof(Articles));
+        }
+
+        /// <summary>
+        /// Encaisse le paiement complet du client
+        /// </summary>
+        public void Payer()
+        {
+            this.sommePayee = this.PrixTotal;
+            this.NotifyPropertyChanged(nameof(SommePayee));
+        }
+
+        /// <summary>
+        /// Remise à zéro de la caisse pour un nouveau client
+        /// </summary>
+        public void Reset()
+        {
+            this.articles.Clear();
+            this.dernierArticleScanne = null;
+            this.quantiteSaisie = 0;
+            this.poidsBalance = 0;
+            this.sommePayee = 0;
+            this.NotifyPropertyChanged(nameof(Articles));
+            this.NotifyPropertyChanged(nameof(SommePayee));
+            this.NotifyPropertyChanged("Reset");
+        }
+
+        /// <summary>
         /// Pattern d'observable
         /// </summary>
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/CaisseAutomatique/VueModel/VMCaisse.cs
+++ b/CaisseAutomatique/VueModel/VMCaisse.cs
@@ -60,7 +60,7 @@ namespace CaisseAutomatique.VueModel
             this.metier = new Caisse();
             this.metier.PropertyChanged += Metier_PropertyChanged;
             this.articles = new ObservableCollection<Article>();
-            this.automate = new Automate();
+            this.automate = new Automate(this.metier);
             this.automate.PropertyChanged += Automate_PropertyChanged;
             this.AjouterLigneTotalEtResteAPayer();
         }
@@ -137,6 +137,8 @@ namespace CaisseAutomatique.VueModel
         /// <param name="vueArticle">Vue de l'article scanné</param>
         public void PasseUnArticleDevantLeScannair(VueArticle vueArticle)
         {
+            this.metier.EnregistrerArticle(vueArticle.Article);
+            this.Scan();
         }
 
         /// <summary>
@@ -169,6 +171,11 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void Paye()
         {
+            if (this.metier.Articles.Count > 0)
+            {
+                this.metier.Payer();
+                this.automate.Activer(Evenement.PAYE);
+            }
         }
 
         /// <summary>
@@ -208,6 +215,7 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void Scan()
         {
+            this.automate.Activer(Evenement.SCAN);
         }
 
         // Implementation of INotifyPropertyChanged


### PR DESCRIPTION
## Summary
- enhance Caisse with article registration, payment and reset
- extend Automate with access to Caisse and new events
- implement states for scanning (`EtatAttenteArticle`) and finished state (`EtatFin`)
- update view model to trigger automate on scan and payment
- add PAYE and RESET transitions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb09704cc832280e512f43f80098f