### PR TITLE
Implémente le mode administrateur

### DIFF
--- a/CaisseAutomatique/Model/Automates/Automate.cs
+++ b/CaisseAutomatique/Model/Automates/Automate.cs
@@ -49,6 +49,8 @@ namespace CaisseAutomatique.Model.Automates
         {
             if (e.PropertyName == "ScanArticleDenombrable")
                 NotifyPropertyChanged("ScanArticleDenombrable");
+            else if (e.PropertyName == "DemandeAdministration")
+                NotifyPropertyChanged("DemandeAdministration");
         }
 
         // INotifyPropertyChanged implementation

--- a/CaisseAutomatique/Model/Automates/Etat.cs
+++ b/CaisseAutomatique/Model/Automates/Etat.cs
@@ -44,5 +44,17 @@ namespace CaisseAutomatique.Model.Automates
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+
+        /// <summary>
+        /// Notification d'ouverture du mode administrateur
+        /// </summary>
+        /// <param name="evt">Evènement reçu</param>
+        protected void NotifierAdministration(Evenement evt)
+        {
+            if (evt == Evenement.ADMIN)
+            {
+                NotifyPropertyChanged("DemandeAdministration");
+            }
+        }
     }
 }

--- a/CaisseAutomatique/Model/Automates/Etats/EtatAttenteArticle.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatAttenteArticle.cs
@@ -13,6 +13,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
+            NotifierAdministration(evt);
             if (evt == Evenement.SCAN && this.automate.Caisse.DernierArticleScanne != null)
             {
                 if (!this.automate.Caisse.DernierArticleScanne.IsDenombrable)
@@ -28,6 +29,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override Etat Transition(Evenement evt)
         {
+            if (evt == Evenement.ADMIN)
+            {
+                return this;
+            }
             if (evt == Evenement.SCAN)
             {
                 if (this.automate.Caisse.DernierArticleScanne != null && this.automate.Caisse.DernierArticleScanne.IsDenombrable)

--- a/CaisseAutomatique/Model/Automates/Etats/EtatAttenteClient.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatAttenteClient.cs
@@ -11,6 +11,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
+            NotifierAdministration(evt);
             if (evt == Evenement.SCAN && this.automate.Caisse.DernierArticleScanne != null)
             {
                 if (!this.automate.Caisse.DernierArticleScanne.IsDenombrable)
@@ -26,6 +27,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override Etat Transition(Evenement evt)
         {
+            if (evt == Evenement.ADMIN)
+            {
+                return this;
+            }
             if (evt == Evenement.SCAN)
             {
                 if (this.automate.Caisse.DernierArticleScanne != null && this.automate.Caisse.DernierArticleScanne.IsDenombrable)

--- a/CaisseAutomatique/Model/Automates/Etats/EtatAttenteDepot.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatAttenteDepot.cs
@@ -13,7 +13,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
-            // aucune action
+            NotifierAdministration(evt);
         }
 
         public override Etat Transition(Evenement evt)
@@ -31,6 +31,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
                 return new EtatFin(this.automate);
             }
             else if (evt == Evenement.SCAN)
+            {
+                return this;
+            }
+            else if (evt == Evenement.ADMIN)
             {
                 return this;
             }

--- a/CaisseAutomatique/Model/Automates/Etats/EtatFin.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatFin.cs
@@ -30,6 +30,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
+            NotifierAdministration(evt);
             if (evt == Evenement.RESET)
             {
                 this.automate.Caisse.Reset();
@@ -48,6 +49,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
                 {
                     return new EtatProblemePoids(this.automate, this);
                 }
+            }
+            else if (evt == Evenement.ADMIN)
+            {
+                return this;
             }
             return this;
         }

--- a/CaisseAutomatique/Model/Automates/Etats/EtatProblemePoids.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatProblemePoids.cs
@@ -16,7 +16,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
-            // aucune action
+            NotifierAdministration(evt);
         }
 
         public override Etat Transition(Evenement evt)
@@ -31,6 +31,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
             else if (evt == Evenement.SCAN || evt == Evenement.PAYE)
             {
                 // ignore events while problem persists
+            }
+            else if (evt == Evenement.ADMIN)
+            {
+                return this;
             }
             return this;
         }

--- a/CaisseAutomatique/Model/Automates/Etats/EtatSaisieQuantite.cs
+++ b/CaisseAutomatique/Model/Automates/Etats/EtatSaisieQuantite.cs
@@ -13,6 +13,7 @@ namespace CaisseAutomatique.Model.Automates.Etats
 
         public override void Action(Evenement evt)
         {
+            NotifierAdministration(evt);
             if (evt == Evenement.SAISIEQUANTITE && this.automate.Caisse.DernierArticleScanne != null)
             {
                 this.automate.Caisse.EnregistrerArticle(this.automate.Caisse.DernierArticleScanne, this.automate.Caisse.QuantiteSaise);
@@ -31,6 +32,10 @@ namespace CaisseAutomatique.Model.Automates.Etats
                 {
                     return new EtatProblemePoids(this.automate, this);
                 }
+            }
+            else if (evt == Evenement.ADMIN)
+            {
+                return this;
             }
             return this;
         }

--- a/CaisseAutomatique/Model/Automates/Evenement.cs
+++ b/CaisseAutomatique/Model/Automates/Evenement.cs
@@ -11,6 +11,7 @@ namespace CaisseAutomatique.Model.Automates
         RESET,
         DEPOSE,
         RETIRE,
-        SAISIEQUANTITE
+        SAISIEQUANTITE,
+        ADMIN
     }
 }

--- a/CaisseAutomatique/Model/Caisse.cs
+++ b/CaisseAutomatique/Model/Caisse.cs
@@ -138,6 +138,32 @@ namespace CaisseAutomatique.Model
         }
 
         /// <summary>
+        /// Annule le dernier article enregistré
+        /// </summary>
+        public void AnnulerDernierArticle()
+        {
+            if (this.articles.Count > 0)
+            {
+                this.articles.RemoveAt(this.articles.Count - 1);
+                this.dernierArticleScanne = this.articles.Count > 0 ? this.articles[^1] : null;
+                this.NotifyPropertyChanged(nameof(Articles));
+            }
+        }
+
+        /// <summary>
+        /// Annule tous les articles de la commande
+        /// </summary>
+        public void AnnulerTousLesArticles()
+        {
+            if (this.articles.Count > 0)
+            {
+                this.articles.Clear();
+                this.dernierArticleScanne = null;
+                this.NotifyPropertyChanged(nameof(Articles));
+            }
+        }
+
+        /// <summary>
         /// Remise à zéro de la caisse pour un nouveau client
         /// </summary>
         public void Reset()

--- a/CaisseAutomatique/VueModel/VMCaisse.cs
+++ b/CaisseAutomatique/VueModel/VMCaisse.cs
@@ -117,6 +117,10 @@ namespace CaisseAutomatique.VueModel
             {
                 this.OuvrirEcranSelectionQuantite();
             }
+            else if (e.PropertyName == "DemandeAdministration")
+            {
+                this.OuvrirEcranAdministration();
+            }
         }
 
         /// <summary>
@@ -193,6 +197,7 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void DebutModeAdministration()
         {
+            this.automate.Activer(Evenement.ADMIN);
         }
 
         /// <summary>
@@ -200,6 +205,7 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void FinModeAdministration()
         {
+            // rien à faire pour le moment
         }
 
         /// <summary>
@@ -207,6 +213,8 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void AnnuleDernierArticle()
         {
+            this.metier.AnnulerDernierArticle();
+            this.automate.Activer(Evenement.RETIRE);
         }
 
         /// <summary>
@@ -214,6 +222,8 @@ namespace CaisseAutomatique.VueModel
         /// </summary>
         public void AnnuleTousLesArticles()
         {
+            this.metier.AnnulerTousLesArticles();
+            this.automate.Activer(Evenement.RETIRE);
         }
 
         ///----------------------

--- a/report.md
+++ b/report.md
@@ -36,3 +36,11 @@
 
 ### Automate actuel
 L'automate comporte désormais les états : `EtatAttenteClient`, `EtatAttenteDepot`, `EtatAttenteArticle`, `EtatProblemePoids`, `EtatSaisieQuantite` et `EtatFin` reliés par les évènements **SCAN**, **DEPOSE**, **RETIRE**, **PAYE**, **RESET** et **SAISIEQUANTITE** permettant de gérer la saisie de quantité pour les articles dénombrables.
+
+### Gestion du mode administrateur
+- ajout de l'évènement **ADMIN** déclenchant l'ouverture de l'interface d'administration
+- possibilité d'annuler le dernier article ou l'ensemble de la commande via cette interface
+- après une annulation, l'automate vérifie à nouveau le poids afin de détecter un éventuel écart
+
+### Automate avec administration
+Les états restent identiques mais acceptent désormais l'évènement **ADMIN** qui n'entraîne pas de changement d'état et demande l'ouverture de l'écran d'administration.


### PR DESCRIPTION
## Summary
- ajoute l'évènement `ADMIN` pour ouvrir l'interface d'administration
- implémente les méthodes d'annulation d'articles dans `Caisse`
- déclenche l'ouverture de l'écran d'administration depuis le vue‑model
- gère l'annulation d'articles via le mode administrateur
- met à jour le rapport avec la nouvelle fonctionnalité

## Testing
- `dotnet build CaisseAutomatique/CaisseAutomatique.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb9fa1c6c83228fd1fc2d7fbcd323